### PR TITLE
Fix: Remove error dialog in settings view when user data fails to load

### DIFF
--- a/EmployeeManagement/app/views/settings.py
+++ b/EmployeeManagement/app/views/settings.py
@@ -27,12 +27,12 @@ class SettingsView(tb.Frame):
             if row:
                 self.user_data["email"] = row[0]
             else:
-                messagebox.showerror("Error", "User not found in database.")
+                print(f"Error: User not found in database for username: {self.username}") # Changed
                 self.user_data["email"] = ""
             cursor.close()
             conn.close()
         except Exception as e:
-            messagebox.showerror("Database Error", f"Failed to load user data:\n{e}")
+            print(f"Database Error: Failed to load user data for {self.username}. Error: {e}") # Changed
             self.user_data["email"] = ""
 
     def build_ui(self):


### PR DESCRIPTION
Previously, if user data (specifically the email) could not be fetched from the database in the settings view (e.g., user not found or other database error), a `messagebox.showerror` dialog would interrupt you.

This commit changes the behavior to:
- Replace the error dialog with `print` statements that output error information to the console. This is less disruptive to you and provides debugging information.
- Ensure that `self.user_data["email"]` is reliably set to an empty string in case of any error during data loading.
- The `build_ui` method already handles an empty email string gracefully, so no UI changes were needed there.

This resolves the issue where an error dialog would appear upon opening the settings view if user data wasn't immediately available.