### PR TITLE
Feat: Make overview statistic cards clickable for navigation

### DIFF
--- a/EmployeeManagement/app/views/dashboard_view.py
+++ b/EmployeeManagement/app/views/dashboard_view.py
@@ -109,7 +109,7 @@ class DashboardView(tb.Frame):
             widget.destroy()
 
         if feature_name == "Dashboard Overview":
-            self.load_view("overview", lambda parent: OverviewPage(parent, self.style))
+            self.load_view("overview", lambda parent: OverviewPage(parent, self.style, self.show_feature))
         elif feature_name == "Employee Data":
             self.load_view("employee", EmployeeView)
         elif feature_name == "Departments":


### PR DESCRIPTION
I've implemented functionality to allow you to click on statistic cards (Total Employees, Attendance Today, Total Payrolls, Departments) on the Overview page to navigate to the respective detailed views.

Changes:
- I modified `OverviewPage` to accept a navigation callback (`show_feature_callback`) from `DashboardView`.
- I updated `DashboardView` to provide its `show_feature` method to `OverviewPage`.
- In `OverviewPage`, statistic cards are now bound with a click event that triggers the navigation callback with the appropriate feature name.
- I added a visual cue: the cursor changes to a hand pointer when hovering over clickable cards.